### PR TITLE
Target .NET 10

### DIFF
--- a/DataEncryptionLayer.Tests/DataEncryptionLayer.Tests.csproj
+++ b/DataEncryptionLayer.Tests/DataEncryptionLayer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/DataEncryptionLayer/DataEncryptionLayer.csproj
+++ b/DataEncryptionLayer/DataEncryptionLayer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
Bumps both projects from `net9.0` to `net10.0`.

.NET 9 is an STS release that has reached end of support and no longer receives security fixes. .NET 10 is the current LTS.

## Changes

- `DataEncryptionLayer.csproj`: `net9.0` -> `net10.0`
- `DataEncryptionLayer.Tests.csproj`: `net9.0` -> `net10.0`

These were the only two framework references in the repo. The `.sln` is version-agnostic and there is no `global.json`, so nothing else required changes. No source changes were needed: every API in use (`ArgumentException.ThrowIfNullOrEmpty`, `Stream.ReadExactly`, `Aes.Create()`, `MD5.Create()`, `CryptoStream`, and the primary constructor on `CryptoStreamReader`) is stable across both targets.

## Not verified locally

This was **not** compiled or tested. The machine it was authored on has no .NET SDK installed (only the .NET 8 runtime), so `dotnet build`, `dotnet test`, and `dotnet list package --vulnerable` were all unavailable. Building this branch also requires the .NET 10 SDK.

Please confirm before merging:

```
dotnet restore && dotnet build && dotnet test
```

## Follow-ups deliberately left out of scope

- The `Rfc2898DeriveBytes` constructors in `FileCryptography` and `TextCryptography` were obsoleted around .NET 9 (`SYSLIB0060`) in favour of the static `Rfc2898DeriveBytes.Pbkdf2` method. If that warning shows up in the build it predates this change rather than being caused by it. The fix is mechanical and format-compatible: `Pbkdf2(password, Salt, 1000, SHA1, 48)` split 32/16 produces byte-identical output to the current `GetBytes(32)` + `GetBytes(16)`, so already-encrypted files still decrypt.
- Test package versions (NUnit 4.2.2, Microsoft.NET.Test.Sdk 17.11.1, NUnit3TestAdapter 4.6.0, NUnit.Analyzers 4.3.0, coverlet.collector 6.0.2) are dated and a framework bump is a natural time to refresh them. Left untouched here rather than guessing version numbers that could not be checked against NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)