### PR TITLE
Fix path derivation, resource leaks and text detection

### DIFF
--- a/DataEncryptionLayer.Tests/FileCryptographyPathTests.cs
+++ b/DataEncryptionLayer.Tests/FileCryptographyPathTests.cs
@@ -1,0 +1,171 @@
+using System.Text;
+
+namespace DataEncryptionLayer.Tests;
+
+/// <summary>
+/// Covers how <see cref="FileCryptography"/> derives the encrypted and decrypted
+/// filenames, which used to be done with raw index arithmetic over the whole path.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(FileCryptography))]
+public class FileCryptographyPathTests
+{
+    #region Setup/Teardown
+
+    private string _directory = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"DataEncryptionLayer_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, true);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Write a file encrypted with the default key/block pair, without going through
+    /// <see cref="FileCryptography.Encrypt(string)"/>, so that the decrypted name can be
+    /// derived from a filename this library would not itself have produced.
+    /// </summary>
+    private void WriteEncryptedFile(string path, string content)
+    {
+        File.WriteAllBytes(path, Utilities.Encrypt(Encoding.UTF8.GetBytes(content), Utilities.DefaultKey, Utilities.DefaultIv));
+    }
+
+    #endregion
+
+    [TestCase("report.txt", "report_txt.crypt")]
+    [TestCase("archive.tar.gz", "archive.tar_gz.crypt")]
+    [TestCase("already_underscored.txt", "already_underscored_txt.crypt")]
+    [TestCase("notes", "notes_.crypt")]
+    [TestCase("my_notes", "my_notes_.crypt")]
+    public void RoundTripsFilenames(string original, string encrypted)
+    {
+        string originalPath = Path.Combine(_directory, original);
+        string encryptedPath = Path.Combine(_directory, encrypted);
+        File.WriteAllText(originalPath, "some content worth protecting");
+        string checksum = FileSigning.ComputeChecksum(originalPath);
+
+        FileCryptography.Encrypt(originalPath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(originalPath), Is.False, "the plaintext file should be retired");
+            Assert.That(File.Exists(encryptedPath), Is.True, "the encrypted file should take the derived name");
+        });
+
+        FileCryptography.Decrypt(encryptedPath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(encryptedPath), Is.False, "the encrypted file should be retired");
+            Assert.That(File.Exists(originalPath), Is.True, "the original name should be restored");
+            Assert.That(FileSigning.ComputeChecksum(originalPath), Is.EqualTo(checksum), "the contents should survive the round trip");
+        });
+    }
+
+    [Test]
+    public void EncryptsAFileWithNoExtension()
+    {
+        // regression: deriving the name indexed from the last '.', so a file without one
+        // threw ArgumentOutOfRangeException before it ever reached the cipher
+        string originalPath = Path.Combine(_directory, "LICENSE");
+        File.WriteAllText(originalPath, "no extension here");
+
+        Assert.DoesNotThrow(() => FileCryptography.Encrypt(originalPath));
+        Assert.That(File.Exists(Path.Combine(_directory, "LICENSE_.crypt")), Is.True);
+    }
+
+    [Test]
+    public void DecryptsIntoADirectoryContainingAnUnderscore()
+    {
+        // regression: the restored name was cut at the last '_' anywhere in the path, so a
+        // directory containing one was spliced into the filename when the stem had none
+        string subdirectory = Path.Combine(_directory, "my_folder");
+        Directory.CreateDirectory(subdirectory);
+
+        string encryptedPath = Path.Combine(subdirectory, "payload.crypt");
+        WriteEncryptedFile(encryptedPath, "hand named");
+
+        FileCryptography.Decrypt(encryptedPath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(Path.Combine(subdirectory, "payload")), Is.True);
+            Assert.That(File.ReadAllText(Path.Combine(subdirectory, "payload")), Is.EqualTo("hand named"));
+        });
+    }
+
+    [Test]
+    public void EncryptsIntoADirectoryContainingADot()
+    {
+        // regression: deriving the name indexed from the last '.' anywhere in the path, so a
+        // dot in a directory name was mistaken for the file's extension
+        string subdirectory = Path.Combine(_directory, "v1.2");
+        Directory.CreateDirectory(subdirectory);
+
+        string originalPath = Path.Combine(subdirectory, "notes");
+        File.WriteAllText(originalPath, "dotted directory");
+
+        FileCryptography.Encrypt(originalPath);
+
+        Assert.That(File.Exists(Path.Combine(subdirectory, "notes_.crypt")), Is.True);
+    }
+
+    [Test]
+    public void AcceptsTheEncryptedExtensionRegardlessOfCase()
+    {
+        string encryptedPath = Path.Combine(_directory, "payload_txt.CRYPT");
+        WriteEncryptedFile(encryptedPath, "mixed case extension");
+
+        FileCryptography.Decrypt(encryptedPath);
+
+        Assert.That(File.Exists(Path.Combine(_directory, "payload.txt")), Is.True);
+    }
+
+    [Test]
+    public void RejectsAFileThatIsNotEncrypted()
+    {
+        string path = Path.Combine(_directory, "plain.txt");
+        File.WriteAllText(path, "not encrypted");
+
+        Assert.Throws<ArgumentException>(() => FileCryptography.Decrypt(path));
+    }
+
+    [Test]
+    public void RejectsAFileWithNoExtensionOnDecrypt()
+    {
+        // regression: this indexed from the last '.' before validating, so it threw
+        // ArgumentOutOfRangeException rather than reporting the real problem
+        string path = Path.Combine(_directory, "extensionless");
+        File.WriteAllText(path, "not encrypted");
+
+        Assert.Throws<ArgumentException>(() => FileCryptography.Decrypt(path));
+    }
+
+    [Test]
+    public void LeavesTheOriginalInPlaceWhenEncryptionCannotBeWritten()
+    {
+        string originalPath = Path.Combine(_directory, "locked.txt");
+        File.WriteAllText(originalPath, "should survive a failed write");
+        string checksum = FileSigning.ComputeChecksum(originalPath);
+
+        // occupy the destination path with a directory so the write cannot succeed. The
+        // rollback then also fails to delete it, which must not mask the real failure.
+        Directory.CreateDirectory(Path.Combine(_directory, "locked_txt.crypt"));
+
+        Assert.Catch(() => FileCryptography.Encrypt(originalPath));
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(originalPath), Is.True, "a failed encryption must not delete the original");
+            Assert.That(FileSigning.ComputeChecksum(originalPath), Is.EqualTo(checksum), "the original must be left intact");
+        });
+    }
+}

--- a/DataEncryptionLayer.Tests/FileSigningTests.cs
+++ b/DataEncryptionLayer.Tests/FileSigningTests.cs
@@ -1,0 +1,107 @@
+namespace DataEncryptionLayer.Tests;
+
+[TestFixture]
+[TestOf(typeof(FileSigning))]
+public class FileSigningTests
+{
+    #region Setup/Teardown
+
+    private string _directory = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"DataEncryptionLayer_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, true);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private string WriteFile(string name, string content)
+    {
+        string path = Path.Combine(_directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    #endregion
+
+    [Test]
+    public void ComputesAThirtyTwoCharacterUppercaseChecksum()
+    {
+        string path = WriteFile("sample.txt", "the quick brown fox");
+
+        string checksum = FileSigning.ComputeChecksum(path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(checksum, Has.Length.EqualTo(32));
+            Assert.That(checksum, Does.Match("^[0-9A-F]{32}$"));
+        });
+    }
+
+    [Test]
+    public void ChecksAFileAgainstItsOwnChecksum()
+    {
+        string path = WriteFile("sample.txt", "the quick brown fox");
+        string checksum = FileSigning.ComputeChecksum(path);
+
+        Assert.That(FileSigning.CheckFile(path, checksum), Is.True);
+    }
+
+    [Test]
+    public void ChecksAFileRegardlessOfChecksumCase()
+    {
+        string path = WriteFile("sample.txt", "the quick brown fox");
+        string checksum = FileSigning.ComputeChecksum(path);
+
+        Assert.That(FileSigning.CheckFile(path, checksum.ToLowerInvariant()), Is.True);
+    }
+
+    [Test]
+    public void DetectsAChangedFile()
+    {
+        string path = WriteFile("sample.txt", "the quick brown fox");
+        string checksum = FileSigning.ComputeChecksum(path);
+
+        File.WriteAllText(path, "the quick brown dog");
+
+        Assert.That(FileSigning.CheckFile(path, checksum), Is.False);
+    }
+
+    [Test]
+    public void RejectsAChecksumOfTheWrongLength()
+    {
+        string path = WriteFile("sample.txt", "the quick brown fox");
+
+        Assert.Throws<ArgumentException>(() => FileSigning.CheckFile(path, "TOOSHORT"));
+    }
+
+    [Test]
+    public void ComparesFilesByContent()
+    {
+        string first = WriteFile("first.txt", "identical content");
+        string second = WriteFile("second.txt", "identical content");
+        string third = WriteFile("third.txt", "different content");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(FileSigning.CompareFiles(first, second), Is.True);
+            Assert.That(FileSigning.CompareFiles(first, third), Is.False);
+        });
+    }
+
+    [Test]
+    public void ThrowsWhenTheFileIsMissing()
+    {
+        Assert.Throws<FileNotFoundException>(() => FileSigning.ComputeChecksum(Path.Combine(_directory, "nope.txt")));
+    }
+}

--- a/DataEncryptionLayer.Tests/UtilitiesTests.cs
+++ b/DataEncryptionLayer.Tests/UtilitiesTests.cs
@@ -1,0 +1,130 @@
+using System.Text;
+
+namespace DataEncryptionLayer.Tests;
+
+[TestFixture]
+[TestOf(typeof(Utilities))]
+public class UtilitiesTests
+{
+    #region Helpers
+
+    /// <summary>
+    /// Build a stream of text padded to a multiple of the AES block size, so that the
+    /// length heuristic in <see cref="Utilities.IsStreamEncrypted"/> cannot short-circuit
+    /// and the content inspection is actually exercised.
+    /// </summary>
+    private static MemoryStream TextStream(string text)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(text);
+
+        int blockSize = Utilities.DefaultIv.Length;
+        byte[] buffer = new byte[(bytes.Length + blockSize - 1) / blockSize * blockSize];
+        Array.Fill(buffer, (byte)' ');
+        bytes.CopyTo(buffer, 0);
+
+        return new MemoryStream(buffer);
+    }
+
+    #endregion
+
+    [Test]
+    public void TabSeparatedTextIsNotReportedAsEncrypted()
+    {
+        // regression: tab is below the printable range, and used to be classified as
+        // non-text even though it is ubiquitous in real text files
+        using MemoryStream stream = TextStream("id\tname\tvalue\n1\tfirst\t100\n2\tsecond\t200\n");
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.False);
+    }
+
+    [Test]
+    public void AccentedTextIsNotReportedAsEncrypted()
+    {
+        // regression: every byte above 127 used to be classified as non-text, so any
+        // UTF-8 text outside ASCII was mistaken for ciphertext
+        using MemoryStream stream = TextStream("café, résumé, naïve, Ünicode, jalapeño");
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.False);
+    }
+
+    [Test]
+    public void TextIsNotReportedAsEncryptedWhenTheSampleCutsAMultiByteCharacter()
+    {
+        // the sample is a fixed size, so it can land mid-character on multi-byte text.
+        // Each of these characters is three bytes, so a 4096-byte sample splits one.
+        using MemoryStream stream = TextStream(new string('日', 1400));
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.False);
+    }
+
+    [Test]
+    public void EncryptedDataIsReportedAsEncrypted()
+    {
+        byte[] cipherText = Utilities.Encrypt(
+            Encoding.UTF8.GetBytes("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
+            Utilities.DefaultKey,
+            Utilities.DefaultIv);
+
+        using MemoryStream stream = new MemoryStream(cipherText);
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.True);
+    }
+
+    [Test]
+    public void BinaryDataIsReportedAsEncrypted()
+    {
+        // a NUL byte does not occur in the text files this heuristic is meant to pass
+        using MemoryStream stream = new MemoryStream(new byte[Utilities.DefaultIv.Length]);
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.True);
+    }
+
+    [Test]
+    public void EmptyStreamIsNotReportedAsEncrypted()
+    {
+        using MemoryStream stream = new MemoryStream();
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.False);
+    }
+
+    [Test]
+    public void DetectionRestoresTheStreamPosition()
+    {
+        byte[] cipherText = Utilities.Encrypt(
+            Encoding.UTF8.GetBytes("position should be left untouched"),
+            Utilities.DefaultKey,
+            Utilities.DefaultIv);
+
+        using MemoryStream stream = new MemoryStream(cipherText);
+        stream.Position = Utilities.DefaultIv.Length;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Utilities.IsStreamEncrypted(stream), Is.True);
+            Assert.That(stream.Position, Is.EqualTo(Utilities.DefaultIv.Length));
+        });
+    }
+
+    [Test]
+    public void DetectionOnAPartiallyReadStreamDoesNotOverrun()
+    {
+        // regression: the length test measured the whole stream but the read started from
+        // the current position. A stream whose total length is a whole number of blocks but
+        // whose remainder is not would pass the length test and then overrun the read.
+        using MemoryStream stream = TextStream("some text padded out to a whole number of blocks");
+        stream.Position = stream.Length - 8;
+
+        Assert.That(Utilities.IsStreamEncrypted(stream), Is.False);
+    }
+
+    [Test]
+    public void RoundTripsBytesThroughEncryptAndDecrypt()
+    {
+        byte[] original = Encoding.UTF8.GetBytes("round trip me");
+
+        byte[] cipherText = Utilities.Encrypt(original, Utilities.DefaultKey, Utilities.DefaultIv);
+        byte[] plainText = Utilities.Decrypt(cipherText, Utilities.DefaultKey, Utilities.DefaultIv);
+
+        Assert.That(plainText, Is.EqualTo(original));
+    }
+}

--- a/DataEncryptionLayer/FileCryptography.cs
+++ b/DataEncryptionLayer/FileCryptography.cs
@@ -7,8 +7,90 @@ namespace DataEncryptionLayer;
 /// </summary>
 public static class FileCryptography
 {
+    /// <summary>
+    /// The extension given to encrypted files
+    /// </summary>
+    private const string EncryptedExtension = ".crypt";
+
+    #region Path Helpers
+
+    /// <summary>
+    /// Work out the encrypted path for a plaintext file, folding the original extension
+    /// into the filename so that <see cref="GetDecryptedPath"/> can restore it.
+    /// "name.ext" becomes "name_ext.crypt"; a file with no extension becomes "name_.crypt".
+    /// </summary>
+    /// <param name="path">The plaintext path</param>
+    /// <returns>The encrypted path</returns>
+    private static string GetEncryptedPath(string path)
+    {
+        // only rewrite the filename: a directory may legitimately contain '.' or '_'
+        string directory = Path.GetDirectoryName(path) ?? string.Empty;
+        string name = Path.GetFileNameWithoutExtension(path);
+        string extension = Path.GetExtension(path);
+
+        // a trailing separator records "there was no extension", which keeps the
+        // transformation reversible for extensionless names that contain '_'
+        string encryptedName = $"{name}_{extension.TrimStart('.')}";
+
+        return Path.Combine(directory, encryptedName + EncryptedExtension);
+    }
+
+    /// <summary>
+    /// Work out the plaintext path for an encrypted file, restoring the extension that
+    /// <see cref="GetEncryptedPath"/> folded into the filename.
+    /// "name_ext.crypt" becomes "name.ext".
+    /// </summary>
+    /// <param name="path">The encrypted path</param>
+    /// <returns>The plaintext path</returns>
+    /// <exception cref="ArgumentException"></exception>
+    private static string GetDecryptedPath(string path)
+    {
+        // only inspect the filename: a directory may legitimately contain '.' or '_'
+        string directory = Path.GetDirectoryName(path) ?? string.Empty;
+        string name = Path.GetFileNameWithoutExtension(path);
+
+        int separator = name.LastIndexOf('_');
+        string decryptedName;
+        if (separator < 0)
+        {
+            // no recorded extension, so restore the name as it stands
+            decryptedName = name;
+        }
+        else
+        {
+            string extension = name[(separator + 1)..];
+            decryptedName = extension.Length > 0
+                ? $"{name[..separator]}.{extension}"
+                : name[..separator];
+        }
+
+        if (decryptedName.Length == 0) throw new ArgumentException("Cannot determine the original filename", nameof(path));
+
+        return Path.Combine(directory, decryptedName);
+    }
+
+    /// <summary>
+    /// Delete a file, ignoring any failure. Used to roll back a partial write without
+    /// masking the exception that caused the rollback.
+    /// </summary>
+    /// <param name="path">The file to delete</param>
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // best effort only: the original exception is the one worth reporting
+        }
+    }
+
+    #endregion
+
+
     #region File IO Factory Methods
-    
+
     /// <summary>
     /// Gets the file output stream.
     /// </summary>
@@ -35,8 +117,16 @@ public static class FileCryptography
         ArgumentException.ThrowIfNullOrEmpty(filename);
         
         Stream outputStream = File.Create(filename);
-        outputStream = new CryptoStream(outputStream, Utilities.GetEncryptor(aesKey, aesIv), CryptoStreamMode.Write);
-        return outputStream;
+        try
+        {
+            return new CryptoStream(outputStream, Utilities.GetEncryptor(aesKey, aesIv), CryptoStreamMode.Write);
+        }
+        catch
+        {
+            // don't leave the file handle open if the transform can't be built
+            outputStream.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -52,14 +142,19 @@ public static class FileCryptography
         if (!File.Exists(filename)) throw new FileNotFoundException(filename);
         
         Stream inputStream = File.OpenRead(filename);
-
-        if (Utilities.IsStreamEncrypted(inputStream))
+        try
         {
             // we weren't given a password, so try to pass the defaults
-            inputStream = GetFileInputStream(inputStream, Utilities.DefaultKey, Utilities.DefaultIv);
+            return Utilities.IsStreamEncrypted(inputStream)
+                ? GetFileInputStream(inputStream, Utilities.DefaultKey, Utilities.DefaultIv)
+                : inputStream;
         }
-
-        return inputStream;
+        catch
+        {
+            // don't leave the file handle open if detection or the transform fails
+            inputStream.Dispose();
+            throw;
+        }
     }
     
     /// <summary>
@@ -77,8 +172,16 @@ public static class FileCryptography
         if (!File.Exists(filename)) throw new FileNotFoundException(filename);
         
         Stream inputStream = File.OpenRead(filename);
-        inputStream = GetFileInputStream(inputStream, aesKey, aesIv);
-        return inputStream;
+        try
+        {
+            return GetFileInputStream(inputStream, aesKey, aesIv);
+        }
+        catch
+        {
+            // don't leave the file handle open if the transform can't be built
+            inputStream.Dispose();
+            throw;
+        }
     }
     
     /// <summary>
@@ -116,7 +219,7 @@ public static class FileCryptography
     public static void Encrypt(string fileToEncrypt, string password)
     {
         // convert the password to a 48-byte array, and render the key/block pair
-        Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
+        using Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
         byte[] aesKey = pdb.GetBytes(32);
         byte[] aesIv = pdb.GetBytes(16);
 
@@ -137,31 +240,21 @@ public static class FileCryptography
         ArgumentException.ThrowIfNullOrEmpty(fileToEncrypt);
         if (!File.Exists(fileToEncrypt)) throw new FileNotFoundException(fileToEncrypt);
         
-        // write the new filename and path
-        string newFileString = fileToEncrypt.Substring(0, fileToEncrypt.LastIndexOf('.')) + "_" +
-                               fileToEncrypt.Substring(fileToEncrypt.LastIndexOf('.') + 1) + ".crypt";
-        
-        // read the input file into a byte array
-        FileStream fsInput = new FileStream(fileToEncrypt, FileMode.Open, FileAccess.Read);
-        byte[] byteArrayInput = new byte[fsInput.Length];
-        fsInput.ReadExactly(byteArrayInput, 0, byteArrayInput.Length);
-        fsInput.Close();
+        // work out the new filename and path
+        string newFileString = GetEncryptedPath(fileToEncrypt);
 
-        // send the input array to the encrypter
-        byte[] byteArrayOutput = Utilities.Encrypt(byteArrayInput, aesKey, aesIv);
-        FileStream fsOutput = new FileStream(newFileString, FileMode.Create, FileAccess.Write);
-        
-        // write the encrypted data to the filestream
+        // read the input file and send it to the encrypter
+        byte[] byteArrayOutput = Utilities.Encrypt(File.ReadAllBytes(fileToEncrypt), aesKey, aesIv);
+
+        // write the encrypted data, then retire the original
         try
         {
-            fsOutput.Write(byteArrayOutput, 0, byteArrayOutput.Length);
-            fsOutput.Close();
+            File.WriteAllBytes(newFileString, byteArrayOutput);
             File.Delete(fileToEncrypt);
         }
         catch
         {
-            fsOutput.Close();
-            File.Delete(newFileString);
+            TryDelete(newFileString);
             throw;
         }
     }
@@ -189,7 +282,7 @@ public static class FileCryptography
     public static void Decrypt(string fileToDecrypt, string password)
     {
         // convert the password to a 48-byte array, and render the key/block pair
-        Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000,  HashAlgorithmName.SHA1);
+        using Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
         byte[] aesKey = pdb.GetBytes(32);
         byte[] aesIv = pdb.GetBytes(16);
 
@@ -210,35 +303,24 @@ public static class FileCryptography
         // catch input exceptions
         ArgumentException.ThrowIfNullOrEmpty(fileToDecrypt);
         if (!File.Exists(fileToDecrypt)) throw new FileNotFoundException(fileToDecrypt);
-        if (fileToDecrypt.Substring(fileToDecrypt.LastIndexOf('.')) != ".crypt") throw new ArgumentException("Not a .crypt file", nameof(fileToDecrypt));
-        
-        // remove the .crypt extension
-        string newFileString = fileToDecrypt.Substring(0, fileToDecrypt.LastIndexOf('_')) + "." +
-                               fileToDecrypt.Substring(fileToDecrypt.LastIndexOf('_') + 1,
-                                   fileToDecrypt.LastIndexOf('.') -
-                                   fileToDecrypt.LastIndexOf('_') - 1);
-        
-        // read the encrypted file
-        FileStream fsInput = new FileStream(fileToDecrypt, FileMode.Open, FileAccess.Read);
-        byte[] byteArrayInput = new byte[fsInput.Length];
-        fsInput.ReadExactly(byteArrayInput, 0, byteArrayInput.Length);
-        fsInput.Close();
+        if (!Path.GetExtension(fileToDecrypt).Equals(EncryptedExtension, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"Not a {EncryptedExtension} file", nameof(fileToDecrypt));
 
-        // call the base-level decryptor and read into an output stream
-        byte[] byteArrayOutput = Utilities.Decrypt(byteArrayInput, aesKey, aesIv);
-        FileStream fsOutput = new FileStream(newFileString, FileMode.Create, FileAccess.Write);
+        // restore the original filename and extension
+        string newFileString = GetDecryptedPath(fileToDecrypt);
 
-        // write the decrypted stream to the new file
+        // read the encrypted file and call the base-level decryptor
+        byte[] byteArrayOutput = Utilities.Decrypt(File.ReadAllBytes(fileToDecrypt), aesKey, aesIv);
+
+        // write the decrypted data, then retire the encrypted file
         try
         {
-            fsOutput.Write(byteArrayOutput, 0, byteArrayOutput.Length);
-            fsOutput.Close();
+            File.WriteAllBytes(newFileString, byteArrayOutput);
             File.Delete(fileToDecrypt);
         }
         catch
         {
-            fsOutput.Close();
-            File.Delete(newFileString);
+            TryDelete(newFileString);
             throw;
         }
     }

--- a/DataEncryptionLayer/FileSigning.cs
+++ b/DataEncryptionLayer/FileSigning.cs
@@ -22,7 +22,7 @@ public static class FileSigning
         if (checksum.Length != 32) throw new ArgumentException("The checksum must be 32 characters long.", nameof(checksum));
         
         // calculate the file checksum value and compare
-        return ComputeChecksum(filename) == checksum.ToUpper();
+        return ComputeChecksum(filename).Equals(checksum, StringComparison.OrdinalIgnoreCase);
     }
     
     /// <summary>
@@ -44,11 +44,11 @@ public static class FileSigning
     /// Compute the MD5 checksum for a file
     /// </summary>
     /// <param name="filename">The file to check</param>
-    /// <returns>A 16-byte hexadecimal string</returns>
+    /// <returns>A 32-character uppercase hexadecimal string</returns>
     public static string ComputeChecksum(string filename)
     {
         // call the base checksum generator and return as string
-        return String.Join("", ComputeMd5Checksum(filename).Select(b => b.ToString("X2")).ToArray());
+        return Convert.ToHexString(ComputeMd5Checksum(filename));
     }
     
     /// <summary>
@@ -57,20 +57,15 @@ public static class FileSigning
     /// <param name="filename">The file to check</param>
     /// <returns>The MD5 checksum as a byte array</returns>
     /// <exception cref="FileNotFoundException"></exception>
-    private static IEnumerable<byte> ComputeMd5Checksum(string filename)
+    private static byte[] ComputeMd5Checksum(string filename)
     {
         // catch input exceptions
         ArgumentException.ThrowIfNullOrEmpty(filename);
         if (!File.Exists(filename)) throw new FileNotFoundException(filename);
-        
-        // read the file into an MD5 hash table
+
+        // read the file into an MD5 hash table and return the hash. The static helper
+        // avoids holding an MD5 instance that would need disposing.
         using FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
-
-        MD5 md5 = MD5.Create();
-        byte[] byteArrayOutput = md5.ComputeHash(fs);
-        fs.Close();
-
-        // return the MD5 hash
-        return byteArrayOutput;
+        return MD5.HashData(fs);
     }
 }

--- a/DataEncryptionLayer/TextCryptography.cs
+++ b/DataEncryptionLayer/TextCryptography.cs
@@ -30,10 +30,10 @@ public static class TextCryptography
     public static string Encrypt(string textToEncrypt, string password)
     {
         // convert the password into a 48-byte array, and render the key/block pair
-        Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
+        using Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
         byte[] aesKey = pdb.GetBytes(32);
         byte[] aesIv = pdb.GetBytes(16);
-        
+
         // call the overload using the new key/block
         return Encrypt(textToEncrypt, aesKey, aesIv);
     }
@@ -97,10 +97,10 @@ public static class TextCryptography
     public static string Decrypt(string textToDecrypt, string password)
     {
         // convert the password to a 48-byte array, and render the key/block pair
-        Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
+        using Rfc2898DeriveBytes pdb = new Rfc2898DeriveBytes(password, Utilities.Salt, 1000, HashAlgorithmName.SHA1);
         byte[] aesKey = pdb.GetBytes(32);
         byte[] aesIv = pdb.GetBytes(16);
-        
+
         // call the overload using the new key/block
         return Decrypt(textToDecrypt, aesKey, aesIv);
     }

--- a/DataEncryptionLayer/Utilities.cs
+++ b/DataEncryptionLayer/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Cryptography;
+using System.Text;
 
 namespace DataEncryptionLayer;
 
@@ -51,6 +52,12 @@ public static class Utilities
         0xCA, 0x07, 0x9D, 0x55
     };
 
+    /// <summary>
+    /// How many bytes <see cref="IsStreamEncrypted"/> samples when inspecting a stream.
+    /// Must be a multiple of the block size.
+    /// </summary>
+    private const int SampleSize = 4096;
+
     #endregion
     
     
@@ -65,7 +72,8 @@ public static class Utilities
     /// <returns></returns>
     public static byte[] Encrypt(byte[] bytesToEncrypt, byte[] aesKey, byte[] aesIv)
     {
-        return Transform(bytesToEncrypt, GetEncryptor(aesKey, aesIv));
+        using ICryptoTransform transform = GetEncryptor(aesKey, aesIv);
+        return Transform(bytesToEncrypt, transform);
     }
     
     /// <summary>
@@ -77,7 +85,8 @@ public static class Utilities
     /// <returns></returns>
     public static byte[] Decrypt(byte[] bytesToDecrypt, byte[] aesKey, byte[] aesIv)
     {
-        return Transform(bytesToDecrypt, GetDecryptor(aesKey, aesIv));
+        using ICryptoTransform transform = GetDecryptor(aesKey, aesIv);
+        return Transform(bytesToDecrypt, transform);
     }
     
     #endregion
@@ -92,45 +101,112 @@ public static class Utilities
     /// <returns><c>true</c> if data is determined to be encrypted</returns>
     private static bool IsDataEncrypted(byte[] data)
     {
-        // AES encryption results in a uniform distribution of byte values from 0-255.
-        // In text files (XML,XAML,et al), most values are not represented at all.
-        // If we encounter only those byte values, we assume the data is encrypted.
-        foreach (byte b in data)
+        // AES encryption results in a uniform distribution of byte values from 0-255, which is
+        // dense with control characters and with sequences that are not legal UTF-8. Text files
+        // (XML, XAML, et al) decode cleanly as UTF-8 and use only a narrow band of control
+        // characters. If the sample does not look like text, we assume the data is encrypted.
+        if (data.Length == 0) return false;
+
+        // The sample may stop part way through a multi-byte character, which would otherwise be
+        // indistinguishable from corruption. Drop any trailing partial sequence before decoding.
+        int length = TrimPartialUtf8Sequence(data);
+        if (length == 0) return true;
+
+        string text;
+        try
         {
-            if ((b < 32 || b > 127)
-                && !( // a few exceptions within those ranges, only tested if the previous test didn't short circuit:
-                        (b == 13 || b == 10) // CR,LF
-                        || (b == 239 || b == 187 || b == 191) // 239 187 191 is the byte order marker for UTF-8
-                    )
-               ) return true;
+            text = new UTF8Encoding(false, true).GetString(data, 0, length);
+        }
+        catch (ArgumentException)
+        {
+            // not legal UTF-8, so not text
+            return true;
         }
 
-        return false;
+        return text.Any(c => !IsTextCharacter(c));
     }
-    
+
+    /// <summary>
+    /// Determine whether a character is one that occurs in ordinary text files
+    /// </summary>
+    /// <param name="character">The character to test</param>
+    /// <returns><c>true</c> if the character is plausible in a text file</returns>
+    private static bool IsTextCharacter(char character)
+    {
+        // tab, newline, carriage return, form feed and the byte order marker are all
+        // legitimate in a text file even though they are control characters
+        if (character is '\t' or '\n' or '\r' or '\f' or '\uFEFF') return true;
+
+        // any other control character is a strong signal of non-text data
+        return !char.IsControl(character);
+    }
+
+    /// <summary>
+    /// Find the length of <paramref name="data"/> excluding any incomplete UTF-8 sequence
+    /// left dangling at the end by sampling
+    /// </summary>
+    /// <param name="data">The data to inspect</param>
+    /// <returns>The length to decode</returns>
+    private static int TrimPartialUtf8Sequence(byte[] data)
+    {
+        // walk back over trailing continuation bytes (10xxxxxx) looking for the lead byte
+        int index = data.Length - 1;
+        int continuationBytes = 0;
+        while (index >= 0 && (data[index] & 0xC0) == 0x80 && continuationBytes < 3)
+        {
+            continuationBytes++;
+            index--;
+        }
+
+        // nothing but continuation bytes: let the decoder reject it
+        if (index < 0) return data.Length;
+
+        int expectedContinuationBytes = (data[index] & 0xE0) == 0xC0 ? 1
+            : (data[index] & 0xF0) == 0xE0 ? 2
+            : (data[index] & 0xF8) == 0xF0 ? 3
+            : 0;
+
+        // if the lead byte promises more continuation bytes than the sample holds, the
+        // sequence is merely truncated rather than invalid, so leave it out of the decode
+        return expectedContinuationBytes > continuationBytes ? index : data.Length;
+    }
+
     /// <summary>
     /// Try to determine if a stream is AES-encrypted.
     /// </summary>
     /// <param name="inputStream">The stream to check. Stream must be Seekable</param>
     /// <returns><c>true</c> if data is determined to be encrypted</returns>
+    /// <exception cref="ArgumentException"></exception>
     public static bool IsStreamEncrypted(Stream inputStream)
     {
-        long dataLength = inputStream.Length;
-        
+        // catch input exceptions
+        ArgumentNullException.ThrowIfNull(inputStream);
+        if (!inputStream.CanSeek) throw new ArgumentException("Stream must be seekable", nameof(inputStream));
+
+        // measure from the current position rather than the whole stream, so that a
+        // partially read stream is not misjudged on length and cannot overrun the read below
+        long restorePosition = inputStream.Position;
+        long dataLength = inputStream.Length - restorePosition;
+
         // no data
-        if (dataLength == 0) return false;
-        
+        if (dataLength <= 0) return false;
+
         // We are using default padding for AesManaged, which pads output to a multiple of the block size.
         // If the file's length is not a multiple of the block size, we know it's NOT encrypted.
         int blockSize = DefaultIv.Length;
         if (dataLength % blockSize != 0) return false;
-        
+
         // fast check failed, look at a sample of the data
-        long restorePosition = inputStream.Position;
-        byte[] testChunk = new byte[blockSize];
-        inputStream.ReadExactly(testChunk, 0, testChunk.Length);
-        inputStream.Position = restorePosition;
-        
+        byte[] testChunk = new byte[(int)Math.Min(dataLength, SampleSize)];
+        try
+        {
+            inputStream.ReadExactly(testChunk, 0, testChunk.Length);
+        }
+        finally
+        {
+            inputStream.Position = restorePosition;
+        }
+
         return IsDataEncrypted(testChunk);
     }
     
@@ -145,10 +221,12 @@ public static class Utilities
     /// <returns>The decryptor</returns>
     public static ICryptoTransform GetDecryptor(byte[]? key = null, byte[]? iv = null)
     {
-        Aes aes = Aes.Create();
+        // the transform holds its own copy of the key material, so the Aes instance
+        // that produced it can be released straight away
+        using Aes aes = Aes.Create();
         aes.Key = key ?? DefaultKey;
         aes.IV = iv ?? DefaultIv;
-        
+
         return aes.CreateDecryptor();
     }
 
@@ -158,10 +236,12 @@ public static class Utilities
     /// <returns>The encryptor</returns>
     public static ICryptoTransform GetEncryptor(byte[]? key = null, byte[]? iv = null)
     {
-        Aes aes = Aes.Create();
+        // the transform holds its own copy of the key material, so the Aes instance
+        // that produced it can be released straight away
+        using Aes aes = Aes.Create();
         aes.Key = key ?? DefaultKey;
         aes.IV = iv ?? DefaultIv;
-        
+
         return aes.CreateEncryptor();
     }
 


### PR DESCRIPTION
Fixes the non-crypto correctness bugs found in the review. No change to the cipher, the key handling, the iteration count or the on-disk format — existing `name_ext.crypt` files still decrypt.

## Filename derivation

Both names were built with raw index arithmetic over the whole path. That threw or produced wrong results in several ordinary cases:

| Input | Before | After |
|---|---|---|
| `LICENSE` (no extension) | `ArgumentOutOfRangeException` | `LICENSE_.crypt` |
| `v1.2/notes` (dot in directory) | dot treated as the extension | `v1.2/notes_.crypt` |
| `my_folder/payload.crypt` | `_` in directory spliced into the name | `my_folder/payload` |
| `extensionless` passed to `Decrypt` | `ArgumentOutOfRangeException` | `ArgumentException` |
| `payload_txt.CRYPT` | rejected (case sensitive) | accepted |

Both are now derived with the `Path` APIs against the filename alone, leaving the directory untouched. Encrypting an extensionless file records the empty extension as a trailing separator (`my_notes` -> `my_notes_.crypt`), which keeps the transformation reversible for names that already contain `_`.

## Text detection

`IsDataEncrypted` classified every byte above 127, and every control byte other than CR/LF, as ciphertext. Two consequences:

- Any file containing a **tab** was reported as encrypted.
- Any **non-ASCII UTF-8** file was reported as encrypted, since the only high bytes it accepted were the three BOM bytes.

It now decodes the sample as UTF-8 and looks for genuine control characters. A multi-byte character split by the sample boundary is tolerated rather than read as corruption. `IsStreamEncrypted` also measures from the current position rather than the whole stream — previously a partially read stream could pass the length test and then overrun the read — and it samples 4 KiB instead of a single block.

This heuristic is still a heuristic. It is better behaved on text, but it cannot distinguish ciphertext from other binary formats, and `GetFileInputStream(string)` still relies on it to decide whether to wrap the stream in a decryptor.

## Resources

`Aes`, `ICryptoTransform`, `Rfc2898DeriveBytes` and `MD5` were all left undisposed. The stream factories leaked the inner `FileStream` if the transform could not be built. Rollback after a failed write called `File.Delete` directly, so a cleanup failure would replace the exception that caused the rollback; it is now best-effort.

## Tests

Adds fixtures for `Utilities` and `FileSigning`, which had none, plus one for the path derivation. The detection and path cases are written as regression tests against the specific behaviours above.

## Not verified locally

As with #2, this was **not** compiled or tested — there is no .NET SDK on the machine it was authored on, only the .NET 8 runtime. I checked brace/paren/region balance across every changed file and traced the round-trip table by hand, but that is not a substitute for `dotnet test`. Please run it before merging; the new fixtures are where I would expect any mistake to surface first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)