### PR TITLE
Add README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+No versions have been tagged yet, so everything below sits under Unreleased. This file starts
+at the .NET 10 upgrade; anything earlier is in the commit log.
+
+## [Unreleased]
+
+### Added
+
+- `README` covering the public API, the `.crypt` naming convention, and the security
+  properties of the built-in defaults.
+- This changelog.
+- Test fixtures for `Utilities` and `FileSigning`, neither of which had any coverage, and one
+  for the encrypted/decrypted filename derivation. ([#3])
+
+### Changed
+
+- Both projects now target .NET 10. .NET 9 is an STS release that has reached end of support
+  and no longer receives security fixes. ([#2])
+- `Utilities.IsStreamEncrypted` now samples up to 4 KiB rather than a single 16-byte block,
+  and decides by decoding the sample as UTF-8 instead of rejecting individual byte values.
+  ([#3])
+- `FileSigning.ComputeChecksum` returns the same 32-character uppercase hex string as before,
+  but via `Convert.ToHexString`. `CheckFile` now compares case-insensitively rather than
+  upper-casing its argument. ([#3])
+
+### Fixed
+
+Filenames were derived with index arithmetic over the whole path, which threw or produced the
+wrong name in several ordinary cases. All of the following are fixed in ([#3]); the on-disk
+format is unchanged, and existing `name_ext.crypt` files still decrypt.
+
+- `Encrypt` threw `ArgumentOutOfRangeException` on a file with no extension. Such a file now
+  encrypts to `name_.crypt`, the trailing separator recording the absent extension so the
+  round trip stays reversible for names that already contain an underscore.
+- `Encrypt` treated a dot in a *directory* name as the file's extension, so `v1.2/notes`
+  produced a mangled path.
+- `Decrypt` cut the restored name at the last underscore anywhere in the path, so a directory
+  containing one was spliced into the filename when the filename itself had none.
+- `Decrypt` indexed from the last dot before validating, so a file with no extension threw
+  `ArgumentOutOfRangeException` instead of reporting that it was not an encrypted file.
+- The `.crypt` extension check was case sensitive, rejecting `payload_txt.CRYPT`.
+
+Encryption detection classified every byte above 127, and every control byte other than CR
+and LF, as ciphertext ([#3]):
+
+- Any file containing a **tab** was reported as encrypted.
+- Any **non-ASCII UTF-8** file was reported as encrypted, since the only high bytes accepted
+  were the three bytes of the byte order mark. Detection now decodes the sample and tolerates
+  a multi-byte character split by the sample boundary.
+- `IsStreamEncrypted` measured length across the whole stream but read from the current
+  position, so a partially read stream could pass the length test and then overrun the read.
+  It now measures the remainder, and restores the position even if the read throws.
+
+Resource handling ([#3]):
+
+- `Aes`, `ICryptoTransform`, `Rfc2898DeriveBytes` and `MD5` instances were created and never
+  disposed.
+- `GetFileOutputStream` and `GetFileInputStream` leaked the inner `FileStream` if the
+  transform could not be constructed.
+- Rollback after a failed write called `File.Delete` directly, so a failure to clean up
+  replaced the exception that caused the rollback. Cleanup is now best-effort.
+
+## Known limitations
+
+Not defects, but consequences of the current design, recorded here so they are not mistaken
+for regressions:
+
+- The default key, IV and salt are compiled in and published in this repository. Data
+  encrypted with the no-argument overloads is obfuscated rather than protected.
+- Because the salt and IV are fixed, encryption is deterministic: the same plaintext and
+  password always yield the same ciphertext.
+- Ciphertext is AES-CBC with no MAC, so tampering is not detected.
+- `FileSigning` uses MD5, which is not collision resistant.
+- `Encrypt` and `Decrypt` delete their input file, and overwrite an existing destination
+  without warning.
+- Encryption detection cannot tell ciphertext from other binary data whose length happens to
+  be a multiple of the block size.
+
+[#2]: https://github.com/erikipedia/DataEncryptionLayer/pull/2
+[#3]: https://github.com/erikipedia/DataEncryptionLayer/pull/3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,181 @@
-"# DataEncryptionLayer" 
+# DataEncryptionLayer
+
+A small .NET class library that wraps AES encryption, file checksums and Luhn check digits
+behind a handful of static helpers. It is aimed at the common case of "encrypt this string
+or this file without me having to think about `CryptoStream`".
+
+Targets .NET 10.
+
+## Contents
+
+| Type | Purpose |
+|---|---|
+| `TextCryptography` | Encrypt and decrypt strings, returning base-64 |
+| `FileCryptography` | Encrypt and decrypt files in place, and open encrypted streams |
+| `FileSigning` | MD5 checksums for comparing files and detecting changes |
+| `NumberSigning` | Luhn check digit generation and validation |
+| `Utilities` | The default key material, byte-array primitives and encryption detection |
+| `CryptoStreamReader` | A `CryptoStream` that tolerates being closed after a partial read |
+
+Every type is a static class except `CryptoStreamReader`.
+
+## Before you use this
+
+**The default key, IV and salt are compiled into the library and published in this
+repository.** They are in [`Utilities.cs`](DataEncryptionLayer/Utilities.cs), including their
+base-64 forms in the doc comments. Anything encrypted with the defaults should be treated as
+obfuscated, not protected — anyone with a copy of this library can decrypt it.
+
+The defaults exist so the no-argument overloads work out of the box. If your data has any
+real confidentiality requirement, pass your own key and IV, or a password, on every call.
+
+Two further properties worth knowing before you build on this:
+
+- **Encryption is deterministic.** The salt and IV are fixed, so the same plaintext with the
+  same password always produces the same ciphertext. That reveals which records are equal to
+  each other, which matters if you are encrypting a column of similar values.
+- **Ciphertext is not authenticated.** This is AES-CBC with no MAC, so tampering is not
+  detected; a decrypt of modified data either yields garbage or throws.
+
+Neither is a bug in the code — they follow from the design — but they decide whether this
+library is the right fit for what you are doing.
+
+## Usage
+
+### Text
+
+```csharp
+using DataEncryptionLayer;
+
+// with the built-in defaults
+string withDefaults = TextCryptography.Encrypt("Hello there!");
+string plainText    = TextCryptography.Decrypt(withDefaults);
+
+// with a password (recommended)
+string withPassword = TextCryptography.Encrypt("Hello there!", "Un1v3rs3!");
+string samePlainText = TextCryptography.Decrypt(withPassword, "Un1v3rs3!");
+
+// with your own key material: a 16, 24 or 32-byte key and a 16-byte IV
+string withOwnKey = TextCryptography.Encrypt("Hello there!", myKey, myIv);
+```
+
+`Encrypt` returns base-64. Decrypting with the wrong password throws
+`CryptographicException`; `TryDecrypt` swallows that and reports success instead, though it
+only ever tries the defaults:
+
+```csharp
+if (TextCryptography.TryDecrypt(cipherText, out string? result))
+{
+    Console.WriteLine(result);
+}
+```
+
+### Files
+
+```csharp
+// encrypt, then decrypt again
+FileCryptography.Encrypt("report.txt");                // -> report_txt.crypt
+FileCryptography.Decrypt("report_txt.crypt");          // -> report.txt
+
+// or with a password
+FileCryptography.Encrypt("report.txt", "Un1v3rs3!");
+FileCryptography.Decrypt("report_txt.crypt", "Un1v3rs3!");
+```
+
+**These calls delete the input file.** `Encrypt` writes the encrypted file and then removes
+the plaintext original; `Decrypt` does the reverse. If the write fails the new file is
+removed and the original is left in place, but there is no point at which both exist, so
+copy anything you cannot afford to lose before calling either. Note also that an existing
+file at the destination is overwritten without warning.
+
+The original extension is folded into the filename so that it can be restored:
+
+| Original | Encrypted |
+|---|---|
+| `report.txt` | `report_txt.crypt` |
+| `archive.tar.gz` | `archive.tar_gz.crypt` |
+| `notes` (no extension) | `notes_.crypt` |
+
+The trailing separator on the last row is what records "there was no extension", which keeps
+the round trip reversible for names that already contain an underscore. Only the filename is
+rewritten; the directory is left alone.
+
+### Streams
+
+`GetFileOutputStream` and `GetFileInputStream` hand back a stream you can read or write
+through, with the cipher already attached. Dispose it as usual.
+
+```csharp
+using (Stream output = FileCryptography.GetFileOutputStream("data.bin", encryptOutputFile: true))
+{
+    output.Write(payload);
+}
+
+// the single-argument reader sniffs the file and attaches a decryptor if it looks encrypted
+using (Stream input = FileCryptography.GetFileInputStream("data.bin"))
+{
+    input.ReadExactly(buffer);
+}
+```
+
+That sniffing is a heuristic — see [Encryption detection](#encryption-detection) below. If you
+know the file is encrypted, pass the key and IV explicitly instead and skip the guesswork.
+
+### Checksums
+
+```csharp
+string checksum = FileSigning.ComputeChecksum("report.txt");   // 32-char uppercase hex
+bool unchanged  = FileSigning.CheckFile("report.txt", checksum);
+bool identical  = FileSigning.CompareFiles("first.txt", "second.txt");
+```
+
+`CheckFile` accepts the checksum in either case. These are MD5, which is fine for spotting
+accidental change or comparing two files you control, but is not collision resistant — do
+not use it to decide whether a file has been tampered with by someone who could choose its
+contents.
+
+### Check digits
+
+```csharp
+string checkDigit = NumberSigning.ComputeCheckDigit("412345678901234");   // "9"
+bool valid        = NumberSigning.CheckNumber("4123456789012349");        // true
+```
+
+Both take an optional `modulus` of 2, 8, 10 or 16, defaulting to decimal:
+
+```csharp
+string hexCheckDigit = NumberSigning.ComputeCheckDigit("1A2B3C", 16);
+```
+
+The digits must match the modulus — `CheckNumber("9", 2)` throws `ArgumentException`, and any
+modulus other than the four supported throws `ArgumentOutOfRangeException`. The check digit
+comes back as a hexadecimal string, so a modulus of 16 can return `A` through `F`.
+
+### Encryption detection
+
+`Utilities.IsStreamEncrypted` guesses whether a seekable stream holds ciphertext. It first
+checks whether the remaining length is a whole number of AES blocks, and if it is, samples up
+to 4 KiB and asks whether that sample decodes as UTF-8 text without stray control characters.
+
+It is a guess, and it is wrong in a predictable direction: **any binary file whose length is
+a multiple of 16 will be reported as encrypted**, because a JPEG and a block of ciphertext
+look equally unlike text. It is reliable at recognising text as *not* encrypted, so treat it
+as a text-versus-not-text test rather than proof of encryption. `GetFileInputStream(string)`
+relies on it, which is why the explicit overload is the better choice when you already know
+what you are opening.
+
+## Building
+
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download).
+
+```
+dotnet restore
+dotnet build
+dotnet test
+```
+
+Tests are NUnit and live in `DataEncryptionLayer.Tests`.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
Re-lands the documentation from #4, which never reached `main`.

#4 was stacked on `fix/path-handling-and-resource-leaks` and merged into that branch rather than into `main`. #3 had already merged the fix commit to `main` on its own, so the docs ended up stranded on a branch with nothing left to merge. `main` currently has all the code fixes but still carries the original one-line README and no changelog.

This is the same commit, cherry-picked onto `main`, and it targets `main` directly. Two new/changed files, no code:

- `README.md` — public API of all six types, worked examples, the `.crypt` naming convention, build and test commands, and the properties a caller needs to know upfront (published default key material, deterministic encryption, unauthenticated ciphertext, input-deleting `Encrypt`/`Decrypt`, MD5 collision resistance, and the limits of encryption detection).
- `CHANGELOG.md` — Keep a Changelog format, everything under Unreleased since there are no tags, starting at the .NET 10 upgrade. Known limitations recorded separately so they are not later mistaken for regressions.

The stranded `fix/path-handling-and-resource-leaks` and `docs/readme-and-changelog` branches can both be deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)